### PR TITLE
implement punch method for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ Start the party which runs on the public server. It will announce itself as `fib
 node examples/punch_simple_servers/rpc_server_public.js
 ```
 
-When you now start `rpc_server_behind_nat.js` it will look up any consumers. It will send a UDP packet to the consumer and establish a temporary local ad-hoc routing in the NAT. When the packet arrives at the public server, it will emit a `punch` event. The public server handles the events, gets and kicks its request for calculation.
+Start `rpc_server_behind_nat.js` on your local machine behind the router now. It looks up possible consumers and sends a UDP packet to the consumer. This establishes a temporary ad-hoc routing for the service running in the home network.
+
+When the packet arrives at the public server, it will emit a `punch` event. The public server handles the event and gets the IP/port from the ad-hoc routing. It then kicks of the request for calculation.
+
 
 ```
 node examples/punch_simple_servers/rpc_server_behind_nat.js

--- a/README.md
+++ b/README.md
@@ -36,7 +36,44 @@ grape --dp 20001 --aph 30001 --bn '127.0.0.1:20002'
 grape --dp 20002 --aph 40001 --bn '127.0.0.1:20001'
 ```
 
-### Testing
+
+### Testing: with just one party behin a NAT
+
+In a lot of scenarios just one party is behind a NAT and the other is available with a public port and IP.
+
+#### Instructions
+
+Run a Grape instance on the public server, lets say the server has the IP `157.81.109.241`:
+
+```
+DEBUG=* grape --dp 20001 --aph 30001 --bn '127.0.0.1:20002'
+```
+
+Then start a Grape instance locally on your machine, behind a NAT, and connect it to the other Grape:
+
+```
+DEBUG=* grape --dp 20002 --aph 30001 --bn '157.81.109.241:20001'
+```
+
+You should see both Grapes connecting to each other.
+
+Start the party which runs on the public server. It will announce itself as `fibonacci_consumer` on the network:
+
+```
+node examples/punch_simple_servers/rpc_server_public.js
+```
+
+When you now start `rpc_server_behind_nat.js` it will look up any consumers. It will send a UDP packet to the consumer and establish a temporary local ad-hoc routing in the NAT. When the packet arrives at the public server, it will emit a `punch` event. The public server handles the events, gets and kicks its request for calculation.
+
+```
+node examples/punch_simple_servers/rpc_server_behind_nat.js
+```
+
+### Testing: with broker
+
+In case both services are behin a NAT, we have to make use of a shared and common broker. This can be a normal server which is reachable by both parties by an address and port kown from all parties.
+
+#### Instructions
 
 Run a Grape instance on a server, lets say the server has the IP `157.81.109.241`:
 

--- a/examples/nat_w_broker/broker.js
+++ b/examples/nat_w_broker/broker.js
@@ -19,7 +19,7 @@ const service = peer.transport('server')
 service.listen()
 
 setInterval(function () {
-  link.announce('etoro_broker', service.port, {})
+  link.announce('fibo_broker', service.port, {})
 }, 1000)
 
 const options = { max: 500, maxAge: 1000 * 15 }
@@ -36,10 +36,10 @@ service.on('request', (rid, key, payload, handler, cert, additional) => {
   const hashed = crypto.createHash('md5').update(JSON.stringify(payload)).digest('hex')
   cache.set(hashed, payload)
 
-  const res = { etoro_cris: {} }
+  const res = { fibonacci_worker: {} }
 
   cache.forEach((v, k) => {
-    res.etoro_cris[k] = v
+    res.fibonacci_worker[k] = v
   })
 
   console.log('#services', JSON.stringify(res, null, ' '))

--- a/examples/nat_w_broker/broker.js
+++ b/examples/nat_w_broker/broker.js
@@ -26,6 +26,8 @@ const options = { max: 500, maxAge: 1000 * 15 }
 const cache = LRU(options)
 
 service.on('request', (rid, key, payload, handler, cert, additional) => {
+  // in the additional variable we get the external IP and port of the sender,
+  // which we will use for our "holepunch registry"
   console.log(`got reply from to ${additional.address}:${additional.port}`)
 
   payload.address = additional.address

--- a/examples/nat_w_broker/nat_server.js
+++ b/examples/nat_w_broker/nat_server.js
@@ -24,7 +24,7 @@ peerClient.init()
 console.log('listening on', service.port)
 
 setInterval(function () {
-  link.announce('etoro_cris', service.port, {})
+  link.announce('fibonacci_worker', service.port, {})
 
   register(peerClient, true, (err, res) => {
     if (err) {
@@ -51,9 +51,28 @@ function connect (peer, clients) {
 }
 
 service.on('request', (rid, key, payload, handler, cert, additional) => {
-  handler.reply(null, 'strategy is everything')
+  console.log('received request, calculating & replying...')
+  const result = fibonacci(payload.length)
+  handler.reply(null, result)
 })
 
 service.on('punch', (other) => {
   console.log('punch from', other)
 })
+
+function fibonacci (length) {
+  const res = []
+
+  function _fibonacci (n) {
+    if (n <= 1) {
+      return 1
+    }
+    return _fibonacci(n - 1) + _fibonacci(n - 2)
+  }
+
+  for (let i = 0; i < length; i++) {
+    res.push(_fibonacci(i))
+  }
+
+  return res
+}

--- a/examples/nat_w_broker/register.js
+++ b/examples/nat_w_broker/register.js
@@ -2,16 +2,16 @@
 
 exports.register = register
 function register (peer, isServer, cb) {
-  peer.request('etoro_broker', {
-    service: 'etoro_cris',
+  peer.request('fibo_broker', {
+    service: 'fibonacci_worker',
     server: isServer
   }, { timeout: 10000 }, (err, data) => {
     if (err) return cb(err)
 
-    const pool = Object.keys(data['etoro_cris'])
+    const pool = Object.keys(data['fibonacci_worker'])
 
     const clients = pool.filter((el) => {
-      const tmp = data['etoro_cris'][el]
+      const tmp = data['fibonacci_worker'][el]
 
       const isClient = !isServer
       if (isClient) {
@@ -22,7 +22,7 @@ function register (peer, isServer, cb) {
     })
 
     const res = clients.map((el) => {
-      return data['etoro_cris'][el]
+      return data['fibonacci_worker'][el]
     })
 
     cb(null, res)

--- a/examples/nat_w_broker/rpc_client.js
+++ b/examples/nat_w_broker/rpc_client.js
@@ -23,7 +23,7 @@ service.on('punch', (other) => {
   })
 })
 
-service.on('error', () => {
+service.on('error', (err) => {
   console.log(err)
   console.trace()
 })
@@ -34,7 +34,6 @@ function kick () {
   register(peer, false, (err, res) => {
     if (err) {
       console.error(err)
-      return
     }
   })
 }

--- a/examples/nat_w_broker/rpc_client.js
+++ b/examples/nat_w_broker/rpc_client.js
@@ -16,7 +16,7 @@ const service = peer.transport('client', {})
 service.on('punch', (other) => {
   console.log('received punch back from', other, 'requesting data...')
 
-  peer.request(other, { msg: 'hello' }, { timeout: 10000 }, (err, data) => {
+  peer.request(other, { length: 10 }, { timeout: 10000 }, (err, data) => {
     if (err) console.error(err)
 
     console.log(data)

--- a/examples/punch_simple/rpc_client.js
+++ b/examples/punch_simple/rpc_client.js
@@ -15,7 +15,7 @@ const client = peer.transport('client', {})
 client.on('punch', (other) => {
   console.log('received punch back from', other, 'requesting data...')
 
-  peer.request('etoro_cris', 'hello', { timeout: 10000 }, (err, data) => {
+  peer.request(other, { length: 10 }, { timeout: 10000 }, (err, data) => {
     console.log('got data reply')
     if (err) console.error(err)
 
@@ -25,6 +25,6 @@ client.on('punch', (other) => {
 
 // convenience method to start a punching process with a grenache service
 // assuming the rpc_server is not behind a nat
-peer.punch('etoro_cris', (err) => {
+peer.punch('fibonacci_worker', (err) => {
   if (err) throw err
 })

--- a/examples/punch_simple_servers/rpc_server_behind_nat.js
+++ b/examples/punch_simple_servers/rpc_server_behind_nat.js
@@ -19,18 +19,19 @@ console.log('listening on', service.port)
 
 setInterval(function () {
   link.announce('fibonacci_worker', service.port, {})
+  peer.punch('fibonacci_consumer')
 }, 1000)
 
 service.on('request', (rid, key, payload, handler, cert, additional) => {
-  console.log('received request, replying...')
+  console.log('received request, calculating & replying...')
   const result = fibonacci(payload.length)
   handler.reply(null, result)
 })
 
 service.on('punch', (other) => {
   console.log('punch from', other)
-  console.log('punching back...')
-  service.punch(other)
+  // console.log('punching back...')
+  // service.punch(other)
 })
 
 function fibonacci (length) {

--- a/examples/punch_simple_servers/rpc_server_public.js
+++ b/examples/punch_simple_servers/rpc_server_public.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const { PeerRPCServer, PeerRPCClient } = require('./../../')
+const Link = require('grenache-nodejs-link')
+
+const link = new Link({
+  grape: 'http://127.0.0.1:30001'
+})
+link.start()
+
+const peerSrv = new PeerRPCServer(link, {
+  timeout: 300000
+})
+peerSrv.init()
+
+const service = peerSrv.transport('server')
+service.listen()
+console.log('listening on', service.port)
+
+const link2 = new Link({
+  grape: 'http://127.0.0.1:30001'
+})
+link2.start()
+
+const peer = new PeerRPCClient(link2, {})
+peer.init()
+
+setInterval(function () {
+  link.announce('fibonacci_consumer', service.port, {})
+}, 1000)
+
+service.on('punch', (other) => {
+  console.log('punch from', other)
+  console.log('punching back...')
+  service.punch(other)
+
+  // establish connection and calculate data
+  peer.request(other, { length: 10 }, { timeout: 10000 }, (err, data) => {
+    if (err) return console.error(err)
+
+    console.log('got data reply')
+    console.log(data)
+  })
+})

--- a/examples/punch_simple_servers/rpc_server_public.js
+++ b/examples/punch_simple_servers/rpc_server_public.js
@@ -38,7 +38,7 @@ service.on('punch', (other) => {
   peer.request(other, { length: 10 }, { timeout: 10000 }, (err, data) => {
     if (err) return console.error(err)
 
-    console.log('got data reply')
+    console.log('got data reply, sequence is:')
     console.log(data)
   })
 })

--- a/lib/PeerRPCClient.js
+++ b/lib/PeerRPCClient.js
@@ -55,4 +55,3 @@ class PeerRPCClient extends Base.PeerRPCClient {
 }
 
 module.exports = PeerRPCClient
-

--- a/lib/PeerRPCServer.js
+++ b/lib/PeerRPCServer.js
@@ -2,10 +2,43 @@
 
 const Base = require('grenache-nodejs-base')
 const TransportRPCServer = require('./TransportRPCServer')
+const { URL } = require('url')
 
 class PeerRPCServer extends Base.PeerRPCServer {
   getTransportClass () {
     return TransportRPCServer
+  }
+
+  getTarget (key, opts, cb) {
+    this.link.lookup(
+      key, {},
+      (err, dests) => {
+        if (err) return cb(err)
+
+        const dest = this.dest(dests, key, opts)
+
+        const u = new URL('http://' + dest)
+
+        const { port, hostname: address } = u
+        const target = {
+          port: +port,
+          address
+        }
+
+        cb(null, { target, dest })
+      }
+    )
+  }
+
+  punch (key, opts = {}, cb = () => {}) {
+    this.getTarget(key, opts, (err, res) => {
+      if (err) return cb(err)
+
+      const cls = this.transport(res.dest, opts)
+
+      cls.punch(res.target)
+      cb(null)
+    })
   }
 }
 

--- a/lib/TransportRPCClient.js
+++ b/lib/TransportRPCClient.js
@@ -87,10 +87,6 @@ class TransportRPCClient extends Base.TransportRPCClient {
     const u = new URL('http://' + this.conf.dest)
     u.host = this.conf.dest
     const { port, hostname: address } = u
-    const target = {
-      port: +port,
-      address
-    }
 
     const socket = this.socket
     this.registerSocket()

--- a/lib/TransportRPCServer.js
+++ b/lib/TransportRPCServer.js
@@ -51,7 +51,7 @@ class TransportRPCServer extends Base.TransportRPCServer {
         }, msg, null, rinfo)
       })
 
-      connection.on('error', (err) => {
+      connection.on('error', () => {
         // this.emit('error', err)
       })
     })

--- a/lib/UtpSocket.js
+++ b/lib/UtpSocket.js
@@ -5,12 +5,6 @@ const Events = require('events')
 const utp = require('utp-native')
 const Holepuncher = require('boxgloves')
 
-const SERVER_PREFIX = 'ò'
-const CLIENT_PREFIX = 'í'
-
-const SERVER_PREFIX_BUF = Buffer.from('ò')
-const CLIENT_PREFIX_BUF = Buffer.from('í')
-
 function getNewBoundSocket (port) {
   const u = utp()
   u.listen(port)
@@ -42,7 +36,7 @@ class UtpSocket extends Events {
   listen () {
     if (this.listening) return
 
-    this.hp.on('msg',  (msg) => {
+    this.hp.on('msg', (msg) => {
       this.emit('msg', msg)
     })
 


### PR DESCRIPTION
 - flesh out examples
 - add instructions for scenarios where just one party is behind
   a NAT
 - added `punch` helper to conveniently send punches from a server
   to an announcing server on the network, e.g.:
   ```js
     server.punch('rest:util:net')
   ```